### PR TITLE
Add new component for handling Jira search using JQL

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from "vue";
 import SettingsDialog from "./components/SettingsDialog.vue";
 import { usePersistedStore } from "./stores/persisted-store";
 import JiraClient from "./services/jira.js";
+import JqlSearch from "./components/JqlSearch.vue";
 
 const showSettingsDialog = ref(false);
 const persistedStore = usePersistedStore();
@@ -59,7 +60,9 @@ onMounted(() => {
 
         <q-page-container>
             <q-page class="container">
-                <div class="row"></div>
+                <div class="row">
+                    <JqlSearch />
+                </div>
             </q-page>
         </q-page-container>
 

--- a/src/components/JqlSearch.vue
+++ b/src/components/JqlSearch.vue
@@ -1,0 +1,78 @@
+<template>
+  <div>
+    <q-input
+      v-model="jqlQuery"
+      label="Enter JQL Query"
+      dense
+      filled
+      style="width: 100%;"
+    />
+    <q-btn @click="performSearch" label="Search" color="primary" />
+
+    <q-select
+      v-model="selectedHistory"
+      :options="searchHistory"
+      label="Search History"
+      dense
+      filled
+      style="width: 100%;"
+      @input="selectHistory"
+    />
+
+    <q-table
+      :rows="searchResults"
+      :columns="columns"
+      row-key="id"
+      :pagination.sync="pagination"
+      :rows-per-page-options="[5, 10, 15]"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import { usePersistedStore } from "../stores/persisted-store";
+import JiraClient from "../services/jira.js";
+
+const jqlQuery = ref("");
+const searchResults = ref([]);
+const searchHistory = ref([]);
+const selectedHistory = ref(null);
+const pagination = ref({
+  page: 1,
+  rowsPerPage: 5,
+  rowsNumber: 0,
+});
+
+const columns = [
+  { name: "summary", required: true, label: "Summary", align: "left", field: "summary" },
+  { name: "status", required: true, label: "Status", align: "left", field: "status" },
+  { name: "assignee", required: true, label: "Assignee", align: "left", field: "assignee" },
+];
+
+const persistedStore = usePersistedStore();
+
+async function performSearch() {
+  const client = JiraClient({
+    host: persistedStore.jiraServerAddress,
+    personalAccessToken: persistedStore.jiraPersonalAccessToken,
+  });
+
+  try {
+    const response = await client.searchIssues(jqlQuery.value, (pagination.value.page - 1) * pagination.value.rowsPerPage, pagination.value.rowsPerPage);
+    searchResults.value = response.issues;
+    pagination.value.rowsNumber = response.total;
+
+    if (!searchHistory.value.includes(jqlQuery.value)) {
+      searchHistory.value.push(jqlQuery.value);
+    }
+  } catch (error) {
+    console.error("Error performing JQL search:", error);
+  }
+}
+
+function selectHistory(query) {
+  jqlQuery.value = query;
+  performSearch();
+}
+</script>

--- a/src/services/jira.js
+++ b/src/services/jira.js
@@ -31,9 +31,35 @@ const JiraClient = (options) => {
         return jiraFetch(`/rest/api/latest/myself`);
     };
 
+    const searchIssues = async (jql, startAt = 0, maxResults = 15, fields = ["summary", "status", "assignee"]) => {
+        const url = "http://" + host + "/rest/api/latest/search";
+        const response = await fetch(url, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${personalAccessToken}`,
+            },
+            body: JSON.stringify({
+                jql,
+                startAt,
+                maxResults,
+                fields,
+            }),
+        });
+
+        if (response.ok) {
+            return response.json();
+        } else {
+            throw new Error(
+                `JiraAPI error! status: ${response.status}, text: ${response.statusText}`,
+            );
+        }
+    };
+
     return {
         getIssue,
         getUser,
+        searchIssues,
     };
 };
 

--- a/tests/unit/JqlSearch.spec.js
+++ b/tests/unit/JqlSearch.spec.js
@@ -1,0 +1,74 @@
+import { mount } from "@vue/test-utils";
+import JqlSearch from "@/components/JqlSearch.vue";
+import { describe, it, expect, vi } from "vitest";
+import JiraClient from "@/services/jira.js";
+
+vi.mock("@/services/jira.js");
+
+describe("JqlSearch.vue", () => {
+  it("renders q-input and q-table correctly", () => {
+    const wrapper = mount(JqlSearch);
+    expect(wrapper.find("input[type='text']").exists()).toBe(true);
+    expect(wrapper.find("table").exists()).toBe(true);
+  });
+
+  it("performs JQL search and updates q-table with results", async () => {
+    const mockSearchResults = {
+      issues: [
+        { id: "1", summary: "Issue 1", status: "Open", assignee: "User A" },
+        { id: "2", summary: "Issue 2", status: "In Progress", assignee: "User B" },
+      ],
+      total: 2,
+    };
+
+    JiraClient.mockImplementation(() => ({
+      searchIssues: vi.fn().mockResolvedValue(mockSearchResults),
+    }));
+
+    const wrapper = mount(JqlSearch);
+    await wrapper.setData({ jqlQuery: "project = TEST" });
+    await wrapper.vm.performSearch();
+
+    expect(wrapper.vm.searchResults).toEqual(mockSearchResults.issues);
+    expect(wrapper.vm.pagination.rowsNumber).toBe(mockSearchResults.total);
+  });
+
+  it("handles pagination correctly", async () => {
+    const mockSearchResults = {
+      issues: [
+        { id: "1", summary: "Issue 1", status: "Open", assignee: "User A" },
+        { id: "2", summary: "Issue 2", status: "In Progress", assignee: "User B" },
+      ],
+      total: 2,
+    };
+
+    JiraClient.mockImplementation(() => ({
+      searchIssues: vi.fn().mockResolvedValue(mockSearchResults),
+    }));
+
+    const wrapper = mount(JqlSearch);
+    await wrapper.setData({ jqlQuery: "project = TEST" });
+    await wrapper.vm.performSearch();
+
+    expect(wrapper.vm.pagination.page).toBe(1);
+    expect(wrapper.vm.pagination.rowsPerPage).toBe(5);
+
+    await wrapper.setData({ pagination: { page: 2, rowsPerPage: 5 } });
+    await wrapper.vm.performSearch();
+
+    expect(wrapper.vm.pagination.page).toBe(2);
+  });
+
+  it("stores and displays search history", async () => {
+    const wrapper = mount(JqlSearch);
+    await wrapper.setData({ jqlQuery: "project = TEST" });
+    await wrapper.vm.performSearch();
+
+    expect(wrapper.vm.searchHistory).toContain("project = TEST");
+
+    await wrapper.setData({ selectedHistory: "project = TEST" });
+    await wrapper.vm.selectHistory("project = TEST");
+
+    expect(wrapper.vm.jqlQuery).toBe("project = TEST");
+  });
+});


### PR DESCRIPTION
Related to #18

Add new component for handling Jira search using JQL.

* **JqlSearch.vue**
  - Create a new Vue component with a `q-input` field for entering the JQL query.
  - Add a `q-table` for displaying the search results.
  - Implement a method to perform the JQL search using the Jira search API.
  - Handle the response and update the `q-table` with the search results.
  - Implement pagination in the `q-table` to handle large collections of items.
  - Add a dropdown or list below the `q-input` field to store and display previous JQL queries.

* **App.vue**
  - Import the new `JqlSearch` component.
  - Add the `JqlSearch` component to the template.

* **jira.js**
  - Add a new method `searchIssues` to handle the JQL search functionality.
  - Include the new `searchIssues` method in the `JiraClient` object.

* **JqlSearch.spec.js**
  - Create a test file for the new `JqlSearch` component.
  - Write tests to verify that the `q-input` field and `q-table` are rendered correctly.
  - Test the method that performs the JQL search to ensure it updates the `q-table` with the search results.
  - Verify that the pagination in the `q-table` works as expected.
  - Write tests to verify the search history feature.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PeterBlenessy/ai-assistant-for-jira-desktop/issues/18?shareId=79475c5f-0606-433b-9021-d9f6c0d47f8b).