### PR TITLE
Add PromptManagement component for managing templates

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@ import SearchHistory from './components/SearchHistory.vue';
 import MarkdownViewer from './components/MarkdownViewer.vue';
 import { useQuasar } from 'quasar';
 import { storeToRefs } from 'pinia';
+import PromptManagement from './components/PromptManagement.vue';
 
 const $q = useQuasar();
 const persistedStore = usePersistedStore();
@@ -20,6 +21,7 @@ const showMenu = ref(false);
 const isConnected = ref(false);
 const user = ref(null);
 const jqlSearch = ref(null);
+const showRightDrawer = ref(false);
 
 const { jiraClient } = useJiraClient();
 
@@ -109,6 +111,7 @@ function handleHistorySelect(query) {
                             </q-item> </q-list>
                     </q-menu>
                 </q-btn>
+                <q-btn flat dense color="grey-6" icon="mdi-format-list-bulleted" @click="showRightDrawer = !showRightDrawer" />
             </q-toolbar>
         </q-header>
 
@@ -128,6 +131,10 @@ function handleHistorySelect(query) {
                     <q-btn flat dense icon="mdi-cog" @click="showMenu = true" />
                 </q-item-section>
             </q-item>
+        </q-drawer>
+
+        <q-drawer side="right" v-model="showRightDrawer" bordered width="35vw">
+            <PromptManagement />
         </q-drawer>
 
         <q-page-container>

--- a/src/components/IssueFields.vue
+++ b/src/components/IssueFields.vue
@@ -88,6 +88,7 @@ import { useJiraClient } from '../composables/JiraClient.js';
 import { useOpenAIClient } from '../composables/OpenAIClient.js';
 import { PROMPT_GENERATE_DESCRIPTION } from "../helpers/prompts.js";
 import { descriptionSchema } from '../helpers/schemas.js';
+import { useTemplateStore } from '../stores/template-store';
 
 const props = defineProps({
     issueKey: {
@@ -102,7 +103,9 @@ const improvementProposal = ref(null);
 
 const { jiraClient } = useJiraClient();
 const { openAIClient } = useOpenAIClient();
-
+const templateStore = useTemplateStore();
+const templates = templateStore.templates;
+const templateMappings = templateStore.templateMappings;
 
 const issueDisplayFields = ['summary', 'description'];
 const improvementDisplayFields = ['summary', 'description', 'mvp', 'acceptanceCriteria'];
@@ -136,6 +139,14 @@ const generateStructuredFormatImprovement = async () => {
         "issueType": getIssueField('issuetype.name'),
         "summary": getIssueField('summary'),
         "description": getIssueField('description')
+    }
+
+    // Retrieve the selected template for the issue type
+    const selectedTemplateId = templateMappings.value[getIssueField('issuetype.name')];
+    const selectedTemplate = templates.value.find(template => template.id === selectedTemplateId);
+
+    if (selectedTemplate) {
+        systemMessage.content = selectedTemplate.content;
     }
 
     let userMessage = { role: "user", content: JSON.stringify(content) };

--- a/src/components/PromptManagement.vue
+++ b/src/components/PromptManagement.vue
@@ -1,0 +1,105 @@
+<template>
+  <q-page class="q-pa-md">
+    <q-card>
+      <q-card-section>
+        <div class="text-h6">Prompt Management</div>
+        <q-btn color="primary" @click="showAddTemplateDialog = true">Add Template</q-btn>
+      </q-card-section>
+
+      <q-separator />
+
+      <q-card-section>
+        <div class="text-subtitle1">Existing Templates</div>
+        <q-list bordered separator>
+          <q-item v-for="template in templates" :key="template.id">
+            <q-item-section>
+              <q-item-label>{{ template.name }}</q-item-label>
+              <q-item-label>{{ template.issueType }}</q-item-label>
+              <q-item-label>{{ template.content }}</q-item-label>
+            </q-item-section>
+            <q-item-section side>
+              <q-btn flat icon="edit" @click="editTemplate(template)" />
+              <q-btn flat icon="delete" @click="deleteTemplate(template.id)" />
+            </q-item-section>
+          </q-item>
+        </q-list>
+      </q-card-section>
+    </q-card>
+
+    <q-dialog v-model="showAddTemplateDialog">
+      <q-card>
+        <q-card-section>
+          <div class="text-h6">Add Template</div>
+        </q-card-section>
+
+        <q-card-section>
+          <q-input v-model="newTemplate.name" label="Template Name" />
+          <q-select v-model="newTemplate.issueType" :options="issueTypes" label="Issue Type" />
+          <q-input v-model="newTemplate.content" label="Template Content" type="textarea" />
+        </q-card-section>
+
+        <q-card-actions align="right">
+          <q-btn flat label="Cancel" @click="showAddTemplateDialog = false" />
+          <q-btn flat label="Save" color="primary" @click="saveTemplate" />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+
+    <q-card>
+      <q-card-section>
+        <div class="text-subtitle1">Select Template for Issue Types</div>
+        <q-list bordered separator>
+          <q-item v-for="issueType in issueTypes" :key="issueType">
+            <q-item-section>
+              <q-item-label>{{ issueType }}</q-item-label>
+            </q-item-section>
+            <q-item-section side>
+              <q-select v-model="templateMappings[issueType]" :options="templateOptions" />
+            </q-item-section>
+          </q-item>
+        </q-list>
+      </q-card-section>
+    </q-card>
+  </q-page>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useTemplateStore } from '../stores/template-store';
+
+const templateStore = useTemplateStore();
+const templates = templateStore.templates;
+const templateMappings = templateStore.templateMappings;
+
+const showAddTemplateDialog = ref(false);
+const newTemplate = ref({
+  name: '',
+  issueType: '',
+  content: ''
+});
+
+const issueTypes = ['initiative', 'epic', 'story', 'task'];
+const templateOptions = templates.map(template => ({ label: template.name, value: template.id }));
+
+function saveTemplate() {
+  templateStore.addTemplate({ ...newTemplate.value, id: Date.now() });
+  newTemplate.value = { name: '', issueType: '', content: '' };
+  showAddTemplateDialog.value = false;
+}
+
+function editTemplate(template) {
+  newTemplate.value = { ...template };
+  showAddTemplateDialog.value = true;
+}
+
+function deleteTemplate(id) {
+  templateStore.deleteTemplate(id);
+}
+</script>
+
+<style scoped>
+.q-page {
+  max-width: 800px;
+  margin: 0 auto;
+}
+</style>

--- a/src/stores/template-store.js
+++ b/src/stores/template-store.js
@@ -1,0 +1,56 @@
+import { ref, watch } from "vue";
+import { defineStore } from "pinia";
+
+export const useTemplateStore = defineStore("template-store", () => {
+  const templates = ref(loadStateFromLocalStorage("templates") || []);
+  const templateMappings = ref(loadStateFromLocalStorage("templateMappings") || {});
+
+  function saveStateToLocalStorage(key, value) {
+    localStorage.setItem(key, JSON.stringify(value));
+  }
+
+  function loadStateFromLocalStorage(key) {
+    const value = localStorage.getItem(key);
+    return value ? JSON.parse(value) : null;
+  }
+
+  function addTemplate(template) {
+    templates.value.push(template);
+    saveStateToLocalStorage("templates", templates.value);
+  }
+
+  function editTemplate(template) {
+    const index = templates.value.findIndex(t => t.id === template.id);
+    if (index !== -1) {
+      templates.value[index] = template;
+      saveStateToLocalStorage("templates", templates.value);
+    }
+  }
+
+  function deleteTemplate(id) {
+    templates.value = templates.value.filter(t => t.id !== id);
+    saveStateToLocalStorage("templates", templates.value);
+  }
+
+  function setTemplateMapping(issueType, templateId) {
+    templateMappings.value[issueType] = templateId;
+    saveStateToLocalStorage("templateMappings", templateMappings.value);
+  }
+
+  watch(templates, (newValue) => {
+    saveStateToLocalStorage("templates", newValue);
+  }, { deep: true });
+
+  watch(templateMappings, (newValue) => {
+    saveStateToLocalStorage("templateMappings", newValue);
+  }, { deep: true });
+
+  return {
+    templates,
+    templateMappings,
+    addTemplate,
+    editTemplate,
+    deleteTemplate,
+    setTemplateMapping
+  };
+});


### PR DESCRIPTION
Fixes #25

Add prompt management functionality to the application.

* **Add PromptManagement Component**
  - Create `PromptManagement.vue` to view, add, edit, and delete templates and examples.
  - Implement a JSON-based model for templates.
  - Add a button labeled "Add Template" to open a dialog for adding templates.
  - Include input fields for template name, issue type, and template content.
  - Add a section to select templates for each issue type.

* **Add Template Store**
  - Create `template-store.js` to manage templates.
  - Define state to include a list of templates and template mappings.
  - Implement actions to add, edit, and delete templates.
  - Persist state to local storage.

* **Update App.vue**
  - Add a right drawer to display the `PromptManagement` component.
  - Add a button in the application toolbar to toggle the drawer visibility.
  - Set the drawer width to 35vw.

* **Update IssueFields.vue**
  - Import and use the template store.
  - Retrieve the selected template for the issue type and include its content in the system message.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PeterBlenessy/ai-assistant-for-jira-desktop/issues/25?shareId=55e505f5-cf5e-41c3-a1bc-16735e596d52).