### PR TITLE
Add process API to Rust backend

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_http::init())
+        .plugin(tauri_plugin_process::init())
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
Fixes #27

Add `tauri_plugin_process` initialization to the Rust backend.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PeterBlenessy/ai-assistant-for-jira-desktop/pull/28?shareId=0ac2d8be-5480-4b08-9884-66233c9bf878).